### PR TITLE
Add compatibility for Laravel 7.0 to 11.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,12 +22,12 @@
     "require": {
         "ext-json": "*",
         "php": "^7.4|^8.0",
-        "illuminate/contracts": "^7.20|^8.19|^9.0|^10.0",
-        "illuminate/support": "^7.20|^8.19|^9.0|^10.0"
+        "illuminate/contracts": "^7.20|^8.19|^9.0|^10.0|^11.0",
+        "illuminate/support": "^7.20|^8.19|^9.0|^10.0|^11.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^7.3",
-        "laravel/framework": "^7.20|^8.19|^9.0|^10.0",
+        "laravel/framework": "^7.20|^8.19|^9.0|^10.0|^11.0",
         "phpunit/phpunit": "^10.0",
         "orchestra/testbench": "^8.5",
         "nunomaduro/collision": "^7.5",


### PR DESCRIPTION
Add compatibility for Laravel 7.0 to 11.0

This commit updates the `composer.json` to ensure that the package is compatible with Laravel versions 7.0 through 11.0. The following changes have been made:

- Updated `illuminate/contracts` and `illuminate/support` requirements to include versions `^7.20|^8.19|^9.0|^10.0|^11.0`.
- Updated `laravel/framework` requirement in `require-dev` to include versions `^7.20|^8.19|^9.0|^10.0|^11.0`.
- Maintained PHP version compatibility with `^7.4|^8.0`.

These changes ensure that the package can be used with the latest Laravel releases while maintaining backward compatibility with earlier versions starting from 7.0.

This commit closes issue #49 by extending the package's compatibility range and addressing the requirements specified in the issue.
